### PR TITLE
DS-509 - [B2B] While creating new formula it shows the code of the already opened formula

### DIFF
--- a/src/app/utils/code-editor/code-editor.component.ts
+++ b/src/app/utils/code-editor/code-editor.component.ts
@@ -1,5 +1,5 @@
 /// <reference path="../../../../node_modules/monaco-editor/monaco.d.ts" />
-import { Component, Input, Output, EventEmitter, AfterViewInit, OnChanges, ElementRef } from '@angular/core';
+import { Component, Input, Output, EventEmitter, AfterViewInit, OnChanges, ElementRef, SimpleChanges } from '@angular/core';
 import { AppService } from '../services/app.service';
 
 let loadedMonaco = false;
@@ -73,9 +73,12 @@ export class CodeEditorComponent implements AfterViewInit, OnChanges {
     });
   }
 
-  ngOnChanges() {
+  ngOnChanges(changes: SimpleChanges) {
     if (this.codeEditorInstance) {
       this.codeEditorInstance.updateOptions({ fontSize: this.fontSize, theme: this.theme, readOnly: !this.edit.status });
+    }
+    if (changes.code && changes.code.currentValue !== changes.code.previousValue && this.code == undefined ) {
+      this.codeEditorInstance.setValue('');
     }
   }
 


### PR DESCRIPTION
The problem occurred because the `code` variable was propagating `undefined` to the code editor whenever a new formula was created. To address this, added a check that verifies if the `code` variable is `undefined`, and if so, sets the value in the code editor to an empty string

