### PR TITLE
DS-546 - [Author] The search bar on author screens is not working

### DIFF
--- a/src/app/home/agents/agents.component.html
+++ b/src/app/home/agents/agents.component.html
@@ -11,7 +11,7 @@
     <div class="options d-flex justify-content-between align-items-center w-100 pt-2 mb-4">
         <div class="fw-600 font-22">Agents</div>
         <span class="d-flex align-items-center">
-            <odp-search-box (enteredText)="searchTerm=$event" (reset)="searchTerm=null"></odp-search-box>
+            <odp-search-box (enteredText)="searchTerm=$event" (reset)="searchTerm=null" [edit]="{status:true}"></odp-search-box>
             <button *ngIf="hasCreatePermission('AGENT')" type="button"
                 class="btn btn-primary ml-3 d-flex align-items-center" (click)="newAgent()">
                 <span class="dsi dsi-plus mr-2"></span>

--- a/src/app/home/api-keys/api-keys-list/api-keys-list.component.html
+++ b/src/app/home/api-keys/api-keys-list/api-keys-list.component.html
@@ -14,7 +14,7 @@
             <span *ngIf="searchTerm" ngbTooltip="Filter Applied" class="dsi dsi-filter-alt text-secondary ml-2"></span>
         </div>
         <div class="d-flex align-items-center">
-            <odp-search-box (enteredText)="searchTerm=$event" (reset)="searchTerm=null"></odp-search-box>
+            <odp-search-box (enteredText)="searchTerm=$event" (reset)="searchTerm=null" [edit]="{status:true}"></odp-search-box>
             <button type="button" id="addNewDS" class="add-new btn btn-primary ml-3 d-flex align-items-center"
                 (click)="newKeyForm()" *ngIf="hasPermission('PMUBC')">
                 <span class="dsi dsi-plus mr-2"></span>

--- a/src/app/home/b2b-flows/b2b-flows.component.html
+++ b/src/app/home/b2b-flows/b2b-flows.component.html
@@ -13,7 +13,7 @@
             <span></span>
         </div>
         <div class="d-flex align-items-center">
-            <odp-search-box (enteredText)="searchTerm=$event" (reset)="searchTerm=null"></odp-search-box>
+            <odp-search-box (enteredText)="searchTerm=$event" (reset)="searchTerm=null" [edit]="{status:true}"></odp-search-box>
             <button type="button" id="data-management" class="btn btn-white d-flex align-items-center border ml-3"
                 [routerLink]="['settings']">
                 <span class="dsi dsi-settings text-secondary"></span>

--- a/src/app/home/connectors/connectors.component.html
+++ b/src/app/home/connectors/connectors.component.html
@@ -10,7 +10,7 @@
   <div class="options d-flex justify-content-between align-items-center w-100 pt-2 mb-4">
     <div class="fw-600 font-22">Connectors</div>
     <div class="d-flex align-items-center">
-      <odp-search-box (enteredText)="searchTerm=$event" (reset)="searchTerm=null"></odp-search-box>
+      <odp-search-box (enteredText)="searchTerm=$event" (reset)="searchTerm=null" [edit]="{status:true}"></odp-search-box>
       <button class="add-new btn btn-primary ml-3 d-flex align-items-center" *ngIf="hasManagePermission('CON')"
         (click)="newConnector()">
         <span class="dsi dsi-plus mr-2"></span>

--- a/src/app/home/control-panel/user-group/user-group.component.html
+++ b/src/app/home/control-panel/user-group/user-group.component.html
@@ -14,7 +14,7 @@
       <span *ngIf="searchTerm" ngbTooltip="Filter Applied" class="dsi dsi-filter-alt text-secondary ml-2"></span>
     </div>
     <div class="d-flex align-items-center">
-      <odp-search-box (enteredText)="searchTerm=$event" (reset)="searchTerm=null"></odp-search-box>
+      <odp-search-box (enteredText)="searchTerm=$event" (reset)="searchTerm=null" [edit]="{status:true}"></odp-search-box>
       <!-- <odp-search-box (enteredText)="searchGroup($event)" (reset)="resetSearch()"></odp-search-box> -->
       <button class="add-new btn btn-primary ml-3 d-flex align-items-center justify-content-center"
         (click)="addNewGroup()" *ngIf="hasPermission('PMGBC')">

--- a/src/app/home/control-panel/user/user.component.html
+++ b/src/app/home/control-panel/user/user.component.html
@@ -21,7 +21,7 @@
         </ng-container>
         <div class="mr-3">
           <odp-search-box (enteredText)="enterToSelect($event)" (reset)="enterToSelect('reset')" [selectOnEnter]="true"
-            (enteredPressed)="enterToSelect($event)"></odp-search-box>
+            (enteredPressed)="enterToSelect($event)" [edit]="{status:true}"></odp-search-box>
         </div>
         <button *ngIf="hasPermission('PMUBC')" type="button" class="add-new btn btn-white border mr-3"
           routerLink="bulk-import" ngbTooltip="Bulk Import" id="bulkimport">

--- a/src/app/home/data-format-listing/data-format-listing.component.html
+++ b/src/app/home/data-format-listing/data-format-listing.component.html
@@ -10,7 +10,7 @@
   <div class="options d-flex justify-content-between align-items-center w-100 pt-2 mb-4">
     <div class="fw-600 font-22">Data Formats</div>
     <div class="d-flex align-items-center">
-      <odp-search-box (enteredText)="searchTerm=$event" (reset)="searchTerm=null"></odp-search-box>
+      <odp-search-box (enteredText)="searchTerm=$event" (reset)="searchTerm=null" [edit]="{status:true}"></odp-search-box>
       <button class="add-new btn btn-primary ml-3 d-flex align-items-center" *ngIf="hasManagePermission('DF')"
         (click)="newDataFormat()">
         <span class="dsi dsi-plus mr-2"></span>

--- a/src/app/home/faas/faas-listing/faas-listing.component.html
+++ b/src/app/home/faas/faas-listing/faas-listing.component.html
@@ -13,7 +13,7 @@
       <span></span>
     </div>
     <div class="d-flex align-items-center">
-      <odp-search-box (enteredText)="searchTerm=$event" (reset)="searchTerm=null"></odp-search-box>
+      <odp-search-box (enteredText)="searchTerm=$event" (reset)="searchTerm=null" [edit]="{status:true}"></odp-search-box>
       <button type="button" id="data-management" class="btn btn-white d-flex align-items-center border ml-3"
        [routerLink]="['settings']">
       <span class="dsi dsi-settings text-secondary"></span>

--- a/src/app/home/library/library.component.html
+++ b/src/app/home/library/library.component.html
@@ -10,7 +10,7 @@
   <div class="options d-flex justify-content-between align-items-center w-100 pt-2 mb-4">
     <div class="fw-600 font-22">Libraries</div>
     <div class="d-flex align-items-center">
-      <odp-search-box (enteredText)="searchTerm=$event" (reset)="searchTerm=null"></odp-search-box>
+      <odp-search-box (enteredText)="searchTerm=$event" (reset)="searchTerm=null" [edit]="{status:true}"></odp-search-box>
       <button class="add-new btn btn-primary ml-3 d-flex align-items-center" *ngIf="hasManagePermission('GS')"
         (click)="newLibrary()">
         <span class="dsi dsi-plus mr-2"></span>

--- a/src/app/home/local-bot/manage-bot-group/manage-bot-group.component.html
+++ b/src/app/home/local-bot/manage-bot-group/manage-bot-group.component.html
@@ -11,7 +11,7 @@
 
 <div class="d-flex mb-4">
     <div>
-        <odp-search-box (enteredText)="searchTerm=$event" (reset)="searchTerm=null" [open]="true">
+        <odp-search-box (enteredText)="searchTerm=$event" (reset)="searchTerm=null" [open]="true" [edit]="{status:true}">
         </odp-search-box>
     </div>
     <div class="d-flex ml-auto mr-2">

--- a/src/app/home/local-bot/manage-bot-key/manage-bot-key.component.html
+++ b/src/app/home/local-bot/manage-bot-key/manage-bot-key.component.html
@@ -12,7 +12,7 @@
 <div class="d-flex mb-4">
     <div>
         <odp-search-box (enteredText)="enterToSelect($event)" (reset)="enterToSelect(null)" [selectOnEnter]="true"
-            [open]="true">
+            [open]="true" [edit]="{status:true}">
         </odp-search-box>
     </div>
     <div class="d-flex ml-auto mr-2">

--- a/src/app/home/local-bot/manage-bot-property/manage-bot-property.component.html
+++ b/src/app/home/local-bot/manage-bot-property/manage-bot-property.component.html
@@ -12,7 +12,7 @@
 <div class="d-flex mb-4">
     <div>
         <odp-search-box (enteredText)="enterToSelect($event)" (reset)="enterToSelect(null)" [selectOnEnter]="true"
-            [open]="true">
+            [open]="true" [edit]="{status:true}">
         </odp-search-box>
     </div>
     <div class="d-flex ml-auto mr-2">

--- a/src/app/home/nodes/nodes.component.html
+++ b/src/app/home/nodes/nodes.component.html
@@ -13,7 +13,7 @@
             <span></span>
         </div>
         <div class="d-flex align-items-center">
-            <odp-search-box (enteredText)="searchTerm=$event" (reset)="searchTerm=null"></odp-search-box>
+            <odp-search-box (enteredText)="searchTerm=$event" (reset)="searchTerm=null" [edit]="{status:true}"></odp-search-box>
             <button type="button" id="data-management" class="btn btn-white d-flex align-items-center border ml-3"
                 [routerLink]="['settings']">
                 <span class="dsi dsi-settings text-secondary"></span>

--- a/src/app/home/process-flows/process-flows.component.html
+++ b/src/app/home/process-flows/process-flows.component.html
@@ -13,7 +13,7 @@
             <span></span>
         </div>
         <div class="d-flex align-items-center">
-            <odp-search-box (enteredText)="searchTerm=$event" (reset)="searchTerm=null"></odp-search-box>
+            <odp-search-box (enteredText)="searchTerm=$event" (reset)="searchTerm=null" [edit]="{status:true}"></odp-search-box>
             <button type="button" id="data-management" class="btn btn-white d-flex align-items-center border ml-3"
                 [routerLink]="['settings']">
                 <span class="dsi dsi-settings text-secondary"></span>

--- a/src/app/home/service-manager/service-manager.component.html
+++ b/src/app/home/service-manager/service-manager.component.html
@@ -13,7 +13,7 @@
       <span *ngIf="searchTerm" ngbTooltip="Filter Applied" class="dsi dsi-filter-alt text-secondary ml-2"></span>
     </div>
     <div class="d-flex align-items-center">
-      <odp-search-box (enteredText)="searchTerm=$event" (reset)="searchTerm=null"></odp-search-box>
+      <odp-search-box (enteredText)="searchTerm=$event" (reset)="searchTerm=null" [edit]="{status:true}"></odp-search-box>
       <button type="button" id="data-management" class="btn btn-white d-flex align-items-center border ml-3"
         [routerLink]="['settings']" *ngIf="isAppAdmin || isSuperAdmin">
         <span class="dsi dsi-settings text-secondary"></span>


### PR DESCRIPTION
We have introduced `edit.status` variable for restricting editing in view mode as part of [DS-32](https://github.com/appveen/ds-ui-author/pull/313/commits/9e3bba775b58cebaf5683758f40c00b2e8e49bd9). Also added `[readonly]='!edit.status'` for input tag in search-box component. 

This fix ensures to pass `edit.status` as `true` for all the author screens to make searching work again.

[Here](https://appveen.atlassian.net/browse/DS-546?focusedCommentId=11528) is the list of screens fixed

[DS-32]: https://appveen.atlassian.net/browse/DS-32?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ